### PR TITLE
Adding support for text/html MediaType

### DIFF
--- a/src/DemoControllers/DemoControllers.csproj
+++ b/src/DemoControllers/DemoControllers.csproj
@@ -107,6 +107,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HTMLControllerSample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AsyncControllerSample.cs" />
     <Compile Include="FromContentControllerSample.cs" />
@@ -122,6 +123,9 @@
       <Project>{837b8ff3-ded6-4dc7-ad58-dbb0b3e44dd4}</Project>
       <Name>WebServer</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/src/DemoControllers/DemoControllers.csproj
+++ b/src/DemoControllers/DemoControllers.csproj
@@ -124,9 +124,6 @@
       <Name>WebServer</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/src/DemoControllers/HTMLControllerSample.cs
+++ b/src/DemoControllers/HTMLControllerSample.cs
@@ -1,0 +1,27 @@
+﻿using Devkoes.Restup.WebServer.Attributes;
+using Devkoes.Restup.WebServer.Models.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Devkoes.Restup.DemoControllers
+{
+    [RestController(InstanceCreationType.Singleton)]
+    public class HTMLControllerSample
+    {
+        [UriFormat("/html")]
+        public GetResponse HTMLExample()
+        {
+            string strResp = "";
+            strResp += "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>HTML Page</title>";
+            strResp += "</head><body><h1>This is a, HTML example</h1><p>";
+            strResp += "This page is returned thru a server running on Windows 10 IOT!";
+            strResp += "<p>it does illustrate the text/html MediaType";
+            strResp += "</body></html>";
+            return new GetResponse(
+                GetResponse.ResponseStatus.OK, strResp);
+        }
+    }
+}

--- a/src/HeadedDemo/MainPage.xaml.cs
+++ b/src/HeadedDemo/MainPage.xaml.cs
@@ -41,6 +41,7 @@ namespace HeadedDemo
             restRouteHandler.RegisterController<SingletonControllerSample>();
             restRouteHandler.RegisterController<ThrowExceptionControllerSample>();
             restRouteHandler.RegisterController<WithResponseContentControllerSample>();
+            restRouteHandler.RegisterController<HTMLControllerSample>();
 
             httpServer.RegisterRoute("api", restRouteHandler);
 

--- a/src/HeadlessDemo/StartupTask.cs
+++ b/src/HeadlessDemo/StartupTask.cs
@@ -39,6 +39,7 @@ namespace Devkoes.Restup.HeadlessDemo
             restRouteHandler.RegisterController<SingletonControllerSample>();
             restRouteHandler.RegisterController<ThrowExceptionControllerSample>();
             restRouteHandler.RegisterController<WithResponseContentControllerSample>();
+            restRouteHandler.RegisterController<HTMLControllerSample>();
 
             httpServer.RegisterRoute("api", restRouteHandler);
             httpServer.RegisterRoute(new StaticFileRouteHandler(@"DemoStaticFiles\Web"));

--- a/src/WebServer/Http/ContentSerializer.cs
+++ b/src/WebServer/Http/ContentSerializer.cs
@@ -19,6 +19,10 @@ namespace Devkoes.Restup.WebServer.Http
             {
                 return XmlDeserializeObject(content, contentType);
             }
+            else if (contentMediaType == MediaType.HTML)
+            {
+                return content.ToString();
+            }
 
             throw new NotImplementedException();
         }
@@ -37,6 +41,10 @@ namespace Devkoes.Restup.WebServer.Http
             else if (req.AcceptMediaType == MediaType.XML)
             {
                 return req.AcceptEncoding.GetBytes(XmlSerializeObject(contentObject));
+            }
+            else if (req.AcceptMediaType == MediaType.HTML)
+            {
+                return req.AcceptEncoding.GetBytes(contentObject.ToString());
             }
 
             return new byte[0];

--- a/src/WebServer/Models/Schemas/MediaType.cs
+++ b/src/WebServer/Models/Schemas/MediaType.cs
@@ -4,6 +4,7 @@
     {
         Unsupported = 0, // Will be the default(MediaType)
         JSON,
-        XML
+        XML,
+        HTML
     }
 }

--- a/src/WebServer/Rest/RestServerRequestFactory.cs
+++ b/src/WebServer/Rest/RestServerRequestFactory.cs
@@ -48,6 +48,9 @@ namespace Devkoes.Restup.WebServer.Rest
                 "text/xml".Equals(contentType, StringComparison.OrdinalIgnoreCase))
                 return MediaType.XML;
 
+            if ("text/html".Equals(contentType, StringComparison.OrdinalIgnoreCase))
+                return MediaType.HTML;
+
             return MediaType.Unsupported;
         }
 
@@ -62,6 +65,10 @@ namespace Devkoes.Restup.WebServer.Rest
                     requestContentCharset = Configuration.Default.DefaultJSONCharset;
                 }
                 else if (contentMediaType == MediaType.XML)
+                {
+                    requestContentCharset = Configuration.Default.DefaultXMLCharset;
+                }
+                else if (contentMediaType == MediaType.HTML)
                 {
                     requestContentCharset = Configuration.Default.DefaultXMLCharset;
                 }
@@ -106,6 +113,10 @@ namespace Devkoes.Restup.WebServer.Rest
                     firstAvailableEncoding = Configuration.Default.DefaultJSONCharset;
                 }
                 else if (acceptMediaType == MediaType.XML)
+                {
+                    firstAvailableEncoding = Configuration.Default.DefaultXMLCharset;
+                }
+                else if (acceptMediaType == MediaType.HTML)
                 {
                     firstAvailableEncoding = Configuration.Default.DefaultXMLCharset;
                 }

--- a/src/WebServer/Rest/RestToHttpResponseConverter.cs
+++ b/src/WebServer/Rest/RestToHttpResponseConverter.cs
@@ -76,6 +76,8 @@ namespace Devkoes.Restup.WebServer.Rest
                     return "application/json";
                 case MediaType.XML:
                     return "application/xml";
+                case MediaType.HTML:
+                    return "text/html";
                 case MediaType.Unsupported:
                     return "";
             }


### PR DESCRIPTION
In order to be able to return full generated HTML pages, added support for MediaType text/html. Browsers are sending this type to client when user is typing the URL in the address bar. You can then return a dynamically generated HTML page.