### PR TITLE
Unencode string parameter values (#63)

### DIFF
--- a/src/WebServer.UnitTests/RestRouteHandlerTest.Happy.cs
+++ b/src/WebServer.UnitTests/RestRouteHandlerTest.Happy.cs
@@ -80,7 +80,7 @@ namespace Restup.Webserver.UnitTests
         }
         #endregion
 
-        #region BasicGetWithAbsoluteUri
+        #region BasicGetWithUriPrefix
         private MutableHttpServerRequest _basicGETUriPrefix = new MutableHttpServerRequest()
         {
             Method = HttpMethod.GET,
@@ -96,6 +96,25 @@ namespace Restup.Webserver.UnitTests
             var response = await m.HandleRequest(_basicGETUriPrefix);
 
             StringAssert.Contains(response.ToString(), "200 OK");
+        }
+        #endregion
+
+        #region BasicGetWithEscapedString
+        private MutableHttpServerRequest _basicGETTextEncoding = new MutableHttpServerRequest()
+        {
+            Method = HttpMethod.GET,
+            Uri = new Uri("/users/John%20Doe", UriKind.RelativeOrAbsolute),
+            IsComplete = true
+        };
+
+        [TestMethod]
+        public async Task HandleRequest_BasicGETTextEncoding_DecodedStringResult()
+        {
+            var m = Utils.CreateRestRoutehandler<HappyPathTestTextEncodingController>();
+
+            var response = await m.HandleRequest(_basicGETTextEncoding);
+
+            StringAssert.Contains(response.ToString(), "John Doe");
         }
         #endregion
 

--- a/src/WebServer.UnitTests/TestHelpers/TestRestControllers.cs
+++ b/src/WebServer.UnitTests/TestHelpers/TestRestControllers.cs
@@ -46,6 +46,16 @@ namespace Restup.Webserver.UnitTests.TestHelpers
     }
 
     [RestController(InstanceCreationType.Singleton)]
+    public class HappyPathTestTextEncodingController
+    {
+        [UriFormat("/users/{name}")]
+        public GetResponse GetUser(string name)
+        {
+            return new GetResponse(GetResponse.ResponseStatus.OK, new User() { Name = name, Age = 30 });
+        }
+    }
+
+    [RestController(InstanceCreationType.Singleton)]
     public class HappyPathTestSingletonControllerWithArgs
     {
         private User _user;

--- a/src/WebServer/Rest/ParameterValueGetter.cs
+++ b/src/WebServer/Rest/ParameterValueGetter.cs
@@ -32,7 +32,8 @@ namespace Restup.Webserver.Rest
             if (parameterType == typeof(string))
             {
                 // String is also an IEnumerable, but should not be treated as one
-                return Convert.ChangeType(parameterValue, parameterType);
+                var unescapedParameterValue = Uri.UnescapeDataString(parameterValue);
+                return Convert.ChangeType(unescapedParameterValue, parameterType);
             }
 
             if (typeof(IEnumerable).IsAssignableFrom(parameterType))


### PR DESCRIPTION
Should fix #63. All string parameter values will be unescaped. Care to review @Jark?