### PR TITLE
Update test framework to use mstest 2 which will hopefully give us less issues.

### DIFF
--- a/src/HttpMessage.UnitTests/HttpMessage.UnitTests.csproj
+++ b/src/HttpMessage.UnitTests/HttpMessage.UnitTests.csproj
@@ -91,7 +91,6 @@
   <ItemGroup>
     <!--A reference to the entire .Net Framework and Windows SDK are automatically included-->
     <None Include="project.json" />
-    <SDKReference Include="MSTestFramework.Universal, Version=$(UnitTestPlatformVersion)" />
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HttpMessage.UnitTests/HttpMessage.UnitTests.nuget.props
+++ b/src/HttpMessage.UnitTests/HttpMessage.UnitTests.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup>
+    <Import Project="$(NuGetPackageRoot)\MSTest.TestAdapter\1.1.3-preview\build\uap10.0\MSTest.TestAdapter.props" Condition="Exists('$(NuGetPackageRoot)\MSTest.TestAdapter\1.1.3-preview\build\uap10.0\MSTest.TestAdapter.props')" />
+  </ImportGroup>
+</Project>

--- a/src/HttpMessage.UnitTests/HttpServerRequestTests.cs
+++ b/src/HttpMessage.UnitTests/HttpServerRequestTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.HttpMessage.UnitTests.TestHelpers;
 using System;

--- a/src/HttpMessage.UnitTests/HttpServerResponseTests.cs
+++ b/src/HttpMessage.UnitTests/HttpServerResponseTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Models.Schemas;
 using System;
 using System.Text;

--- a/src/HttpMessage.UnitTests/project.json
+++ b/src/HttpMessage.UnitTests/project.json
@@ -1,6 +1,8 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "MSTest.TestAdapter": "1.1.3-preview",
+    "MSTest.TestFramework": "1.0.4-preview"
   },
   "frameworks": {
     "uap10.0": {}

--- a/src/WebServer.UnitTests/File/MimeTypeProviderTests.cs
+++ b/src/WebServer.UnitTests/File/MimeTypeProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.File;
 using Restup.Webserver.UnitTests.TestHelpers;
 using System;

--- a/src/WebServer.UnitTests/File/StaticFileRouteHandlerTests.cs
+++ b/src/WebServer.UnitTests/File/StaticFileRouteHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.UnitTests.TestHelpers;
 using Windows.ApplicationModel;

--- a/src/WebServer.UnitTests/Http/HttpServerTests.ContentEncoding.cs
+++ b/src/WebServer.UnitTests/Http/HttpServerTests.ContentEncoding.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Headers.Response;
 using Restup.Webserver.UnitTests.TestHelpers;
 using ContentTypeHeader = Restup.HttpMessage.Headers.Request.ContentTypeHeader;

--- a/src/WebServer.UnitTests/Http/HttpServerTests.CorsPreflightedRequests.cs
+++ b/src/WebServer.UnitTests/Http/HttpServerTests.CorsPreflightedRequests.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Headers.Response;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.UnitTests.TestHelpers;

--- a/src/WebServer.UnitTests/Http/HttpServerTests.CorsSimpleRequests.cs
+++ b/src/WebServer.UnitTests/Http/HttpServerTests.CorsSimpleRequests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Text;
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Headers.Response;
 using Restup.Webserver.UnitTests.TestHelpers;
 

--- a/src/WebServer.UnitTests/Http/HttpServerTests.HandleRequest.cs
+++ b/src/WebServer.UnitTests/Http/HttpServerTests.HandleRequest.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.Http;
 using Restup.Webserver.UnitTests.TestHelpers;

--- a/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.ArrayParameters.cs
+++ b/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.ArrayParameters.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.Attributes;
 using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;

--- a/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.AsyncMethods.cs
+++ b/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.AsyncMethods.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.Attributes;
 using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;

--- a/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.MultipleSimilarlyNamedMethods.cs
+++ b/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.MultipleSimilarlyNamedMethods.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.Attributes;
 using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;

--- a/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.QueryParameters.cs
+++ b/src/WebServer.UnitTests/Rest/RestControllerRequestHandlerTests.QueryParameters.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.Attributes;
 using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.UnitTests.TestHelpers;

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Rainy.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Rainy.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.Attributes;

--- a/src/WebServer.UnitTests/Rest/RestToHttpResponseConverterTests.cs
+++ b/src/WebServer.UnitTests/Rest/RestToHttpResponseConverterTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.Webserver.Models.Schemas;
 using Restup.Webserver.Rest;
 using System.Collections.Generic;

--- a/src/WebServer.UnitTests/TestHelpers/FluentHttpServerTests.cs
+++ b/src/WebServer.UnitTests/TestHelpers/FluentHttpServerTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage;
 using Restup.HttpMessage.Models.Contracts;
 using Restup.HttpMessage.Models.Schemas;

--- a/src/WebServer.UnitTests/TestHelpers/StaticFileRouteHandlerTests.Fluent.cs
+++ b/src/WebServer.UnitTests/TestHelpers/StaticFileRouteHandlerTests.Fluent.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Restup.HttpMessage;
 using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.File;

--- a/src/WebServer.UnitTests/WebServer.UnitTests.csproj
+++ b/src/WebServer.UnitTests/WebServer.UnitTests.csproj
@@ -92,7 +92,6 @@
   <ItemGroup>
     <!--A reference to the entire .Net Framework and Windows SDK are automatically included-->
     <None Include="project.json" />
-    <SDKReference Include="MSTestFramework.Universal, Version=$(UnitTestPlatformVersion)" />
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/WebServer.UnitTests/Webserver.UnitTests.nuget.props
+++ b/src/WebServer.UnitTests/Webserver.UnitTests.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup>
+    <Import Project="$(NuGetPackageRoot)\MSTest.TestAdapter\1.1.3-preview\build\uap10.0\MSTest.TestAdapter.props" Condition="Exists('$(NuGetPackageRoot)\MSTest.TestAdapter\1.1.3-preview\build\uap10.0\MSTest.TestAdapter.props')" />
+  </ImportGroup>
+</Project>

--- a/src/WebServer.UnitTests/project.json
+++ b/src/WebServer.UnitTests/project.json
@@ -1,6 +1,8 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "MSTest.TestAdapter": "1.1.3-preview",
+    "MSTest.TestFramework": "1.0.4-preview"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
I have had multiple issues with the ms test adapter and came across this blog post:  https://blogs.msdn.microsoft.com/visualstudioalm/2016/06/17/taking-the-mstest-framework-forward-with-mstest-v2/ 

I had a go at upgrading it and turns out it's really easy!

Should be a quick review @tomkuijsten :)
