### PR TITLE
Added validation for unique URIs

### DIFF
--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
@@ -1,0 +1,105 @@
+﻿using Restup.HttpMessage.Models.Schemas;
+using Restup.Webserver.Attributes;
+using Restup.Webserver.Models.Contracts;
+using Restup.Webserver.Models.Schemas;
+using Restup.Webserver.Rest;
+using Restup.Webserver.UnitTests.TestHelpers;
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Restup.Webserver.UnitTests.Rest
+{
+    [TestClass]
+    public class RestRouteHandlerTests_UriFormatValidation
+    {
+        private RestRouteHandler restHandler;
+
+        [TestInitialize()]
+        public void Initialize()
+        {
+            restHandler = new RestRouteHandler();
+        }
+
+        private class TwoUriFormatWithSameNameAndMethodController
+        {
+            [UriFormat("/Get")]
+            public IGetResponse Get() => new GetResponse(GetResponse.ResponseStatus.OK);
+
+            [UriFormat("/Get")]
+            public IGetResponse Get2() => new GetResponse(GetResponse.ResponseStatus.OK);
+        }
+
+        [TestMethod]
+        public async Task RegisterController_OneControllerWithTwoMethodsWithSameNameAndMethod_ThrowsException()
+        {
+            AssertRegisterControllerThrows<TwoUriFormatWithSameNameAndMethodController>();
+            await AssertHandleRequest("/Get", HttpMethod.GET, HttpResponseStatus.BadRequest);
+        }
+
+        private class OnePostMethodController
+        {
+            [UriFormat("/Post")]
+            public IPostResponse Post() => new PostResponse(PostResponse.ResponseStatus.Created);
+        }
+
+        [TestMethod]
+        public async Task RegisterController_OneControllerRegisteredTwice_ThrowsException()
+        {
+            restHandler.RegisterController<OnePostMethodController>();
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+            AssertRegisterControllerThrows<OnePostMethodController>();
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+        }
+
+        private class OnePostMethodWithParameterizedConstructorController
+        {
+            [UriFormat("/Post")]
+            public IPostResponse Post() => new PostResponse(PostResponse.ResponseStatus.Created);
+
+            public OnePostMethodWithParameterizedConstructorController(string param)
+            {
+            }
+        }
+
+        [TestMethod]
+        public async Task RegisterController_OneParameterizedControllerRegisteredTwice_ThrowsException()
+        {
+            restHandler.RegisterController<OnePostMethodWithParameterizedConstructorController>("param");
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+            AssertRegisterControllerThrows<OnePostMethodWithParameterizedConstructorController>("param");
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+        }
+
+        [TestMethod]
+        public async Task RegisterController_TwoDifferentControllersWithSimilarlyNamedMethodsAndVerbs_ThrowsException()
+        {
+            restHandler.RegisterController<OnePostMethodController>();
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+            AssertRegisterControllerThrows<OnePostMethodWithParameterizedConstructorController>("param");
+            await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
+        }
+
+        private void AssertRegisterControllerThrows<T>(params string[] args) where T : class
+        {
+            Assert.ThrowsException<Exception>(() =>
+                restHandler.RegisterController<T>(args)
+            );
+        }
+
+        private void AssertRegisterControllerThrows<T>() where T : class
+        {
+            Assert.ThrowsException<Exception>(() =>
+                restHandler.RegisterController<T>()
+            );
+        }
+
+        private async Task AssertHandleRequest(string uri, HttpMethod method, HttpResponseStatus expectedStatus)
+        {
+            var request = Utils.CreateHttpRequest(uri: new Uri(uri, UriKind.Relative), method: method);
+            var result = await restHandler.HandleRequest(request);
+
+            Assert.AreEqual(expectedStatus, result.ResponseStatus);
+        }
+    }
+}

--- a/src/WebServer.UnitTests/WebServer.UnitTests.csproj
+++ b/src/WebServer.UnitTests/WebServer.UnitTests.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Restup.Webserver.UnitTests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -98,6 +98,7 @@
     <Compile Include="File\MimeTypeProviderTests.cs" />
     <Compile Include="Http\HttpServerTests.CorsSimpleRequests.cs" />
     <Compile Include="Http\HttpServerTests.CorsPreflightedRequests.cs" />
+    <Compile Include="Rest\RestRouteHandlerTests.UriFormatValidation.cs" />
     <Compile Include="TestHelpers\MockFile.cs" />
     <Compile Include="TestHelpers\MockFileSystem.cs" />
     <Compile Include="TestHelpers\StaticFileRouteHandlerTests.Fluent.cs" />

--- a/src/WebServer/Constants.cs
+++ b/src/WebServer/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Restup.WebServer
+{
+    internal class Constants
+    {
+        public const int HashCodePrime = 397;
+    }
+}

--- a/src/WebServer/Rest/PathPart.cs
+++ b/src/WebServer/Rest/PathPart.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Restup.Webserver.Rest
 {
     public class PathPart
@@ -15,6 +17,27 @@ namespace Restup.Webserver.Rest
         {
             PartType = pathPartType;
             Value = value;
+        }
+
+        protected bool Equals(PathPart other)
+        {
+            return PartType == other.PartType && string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((PathPart)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((int)PartType * 397) ^ (Value?.GetHashCode() ?? 0);
+            }
         }
     }
 }

--- a/src/WebServer/Rest/PathPart.cs
+++ b/src/WebServer/Rest/PathPart.cs
@@ -1,4 +1,5 @@
 using System;
+using Restup.WebServer;
 
 namespace Restup.Webserver.Rest
 {
@@ -36,7 +37,7 @@ namespace Restup.Webserver.Rest
         {
             unchecked
             {
-                return ((int)PartType * 397) ^ (Value?.GetHashCode() ?? 0);
+                return ((int)PartType * Constants.HashCodePrime) ^ (Value?.GetHashCode() ?? 0);
             }
         }
     }

--- a/src/WebServer/Rest/RestControllerMethodInfo.cs
+++ b/src/WebServer/Rest/RestControllerMethodInfo.cs
@@ -20,9 +20,9 @@ namespace Restup.Webserver.Rest
         private readonly IEnumerable<Type> _validParameterTypes;
 
         private readonly UriParser _uriParser;
-        private readonly ParsedUri _matchUri;
         private readonly IEnumerable<ParameterValueGetter> _parameterGetters;
 
+        internal ParsedUri MatchUri { get; }
         internal MethodInfo MethodInfo { get; }
         internal HttpMethod Verb { get; }
         internal bool HasContentParameter { get; }
@@ -37,7 +37,7 @@ namespace Restup.Webserver.Rest
         {
             constructorArgs.GuardNull(nameof(constructorArgs));
             _uriParser = new UriParser();
-            _matchUri = GetUriFromMethod(methodInfo);
+            MatchUri = GetUriFromMethod(methodInfo);
 
             ReturnTypeWrapper = typeWrapper;
             ControllerConstructorArgs = constructorArgs;
@@ -121,7 +121,7 @@ namespace Restup.Webserver.Rest
                 throw new InvalidOperationException("Can't use method parameters with a custom type.");
             }
 
-           return fromUriParams.Select(x => GetParameterGetter(x, _matchUri)).ToArray();
+            return fromUriParams.Select(x => GetParameterGetter(x, MatchUri)).ToArray();
         }
 
         private static ParameterValueGetter GetParameterGetter(ParameterInfo parameterInfo, ParsedUri matchUri)
@@ -183,12 +183,12 @@ namespace Restup.Webserver.Rest
 
         internal bool Match(ParsedUri uri)
         {
-            if (_matchUri.PathParts.Count != uri.PathParts.Count)
+            if (MatchUri.PathParts.Count != uri.PathParts.Count)
                 return false;
 
-            for (var i = 0; i < _matchUri.PathParts.Count; i++)
+            for (var i = 0; i < MatchUri.PathParts.Count; i++)
             {
-                var fromPart = _matchUri.PathParts[i];
+                var fromPart = MatchUri.PathParts[i];
                 var toPart = uri.PathParts[i];
                 if (fromPart.PartType == PathPart.PathPartType.Argument)
                     continue;
@@ -197,10 +197,10 @@ namespace Restup.Webserver.Rest
                     return false;
             }
 
-            if (uri.Parameters.Count < _matchUri.Parameters.Count)
+            if (uri.Parameters.Count < MatchUri.Parameters.Count)
                 return false;
 
-            return _matchUri.Parameters.All(x => uri.Parameters.Any(y => y.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase)));
+            return MatchUri.Parameters.All(x => uri.Parameters.Any(y => y.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase)));
         }
 
         internal IEnumerable<object> GetParametersFromUri(ParsedUri uri)
@@ -210,7 +210,7 @@ namespace Restup.Webserver.Rest
 
         public override string ToString()
         {
-            return $"Hosting {Verb} method on {_matchUri}";
+            return $"Hosting {Verb} method on {MatchUri}";
         }
     }
 }

--- a/src/WebServer/Rest/RestControllerMethodInfoValidator.cs
+++ b/src/WebServer/Rest/RestControllerMethodInfoValidator.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Restup.Webserver.Rest
+{
+    internal class RestControllerMethodInfoValidator
+    {
+        private readonly UniqueMatchUriAndVerbRestControllerMethodInfoComparer _uniqueMatchUriAndVerbComparer;
+
+        public RestControllerMethodInfoValidator()
+        {
+            _uniqueMatchUriAndVerbComparer = new UniqueMatchUriAndVerbRestControllerMethodInfoComparer();
+        }
+
+        public void Validate<T>(ImmutableArray<RestControllerMethodInfo> existingRestMethodCollection,
+            IList<RestControllerMethodInfo> restControllerMethodInfos)
+        {
+            foreach (var restControllerMethodInfo in restControllerMethodInfos)
+            {
+                // if the existing rest method collection already contains the rest controller method to be added 
+                // or if the rest controller method infos to be added contains more than one rest method info with the same path
+                // then throw an exception                 
+                if (existingRestMethodCollection.Contains(restControllerMethodInfo, _uniqueMatchUriAndVerbComparer)
+                    || restControllerMethodInfos.Count(x => _uniqueMatchUriAndVerbComparer.Equals(x, restControllerMethodInfo)) > 1)
+                {
+                    throw new Exception($"Can't register route for controller {typeof(T)}, UriFormat with {restControllerMethodInfo.MatchUri} and {restControllerMethodInfo.Verb} since this would cause multiple routes to be registered on the same name.");
+                }
+            }
+        }
+    }
+}

--- a/src/WebServer/Rest/UniqueMatchUriAndVerbComparer.cs
+++ b/src/WebServer/Rest/UniqueMatchUriAndVerbComparer.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Restup.Webserver.Rest
+{
+    internal class UniqueMatchUriAndVerbRestControllerMethodInfoComparer : IEqualityComparer<RestControllerMethodInfo>
+    {
+        private readonly PathPartsAndParametersParsedUriComparer _parsedUriComparer;
+
+        public UniqueMatchUriAndVerbRestControllerMethodInfoComparer()
+        {
+            _parsedUriComparer = new PathPartsAndParametersParsedUriComparer();
+        }
+
+        public bool Equals(RestControllerMethodInfo x, RestControllerMethodInfo y)
+        {
+            return _parsedUriComparer.Equals(x.MatchUri, y.MatchUri) && x.Verb == y.Verb;
+        }
+
+        public int GetHashCode(RestControllerMethodInfo obj)
+        {
+            unchecked
+            {
+                return ((obj.MatchUri?.GetHashCode() ?? 0) * 397) ^ (int)obj.Verb;
+            }
+        }
+
+        internal class PathPartsAndParametersParsedUriComparer : IEqualityComparer<ParsedUri>
+        {
+            public bool Equals(ParsedUri x, ParsedUri y)
+            {
+                return x.PathParts.SequenceEqual(y.PathParts) && x.Parameters.SequenceEqual(y.Parameters);
+            }
+
+            public int GetHashCode(ParsedUri obj)
+            {
+                unchecked
+                {
+                    return ((obj.Parameters?.GetHashCode() ?? 0) * 397) ^ (obj.PathParts?.GetHashCode() ?? 0);
+                }
+            }
+        }
+    }
+}

--- a/src/WebServer/Rest/UniqueMatchUriAndVerbComparer.cs
+++ b/src/WebServer/Rest/UniqueMatchUriAndVerbComparer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Restup.WebServer;
 
 namespace Restup.Webserver.Rest
 {
@@ -21,7 +22,7 @@ namespace Restup.Webserver.Rest
         {
             unchecked
             {
-                return ((obj.MatchUri?.GetHashCode() ?? 0) * 397) ^ (int)obj.Verb;
+                return ((obj.MatchUri?.GetHashCode() ?? 0) * Constants.HashCodePrime) ^ (int)obj.Verb;
             }
         }
 
@@ -36,7 +37,7 @@ namespace Restup.Webserver.Rest
             {
                 unchecked
                 {
-                    return ((obj.Parameters?.GetHashCode() ?? 0) * 397) ^ (obj.PathParts?.GetHashCode() ?? 0);
+                    return ((obj.Parameters?.GetHashCode() ?? 0) * Constants.HashCodePrime) ^ (obj.PathParts?.GetHashCode() ?? 0);
                 }
             }
         }

--- a/src/WebServer/Rest/UriParameter.cs
+++ b/src/WebServer/Rest/UriParameter.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Restup.Webserver.Rest
 {
     internal class UriParameter
@@ -14,6 +16,28 @@ namespace Restup.Webserver.Rest
         {
             Name = name;
             Value = value;
+        }
+
+        protected bool Equals(UriParameter other)
+        {
+            return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((UriParameter) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name?.GetHashCode() ?? 0)*397) ^ (Value?.GetHashCode() ?? 0);
+            }
         }
     }
 }

--- a/src/WebServer/Rest/UriParameter.cs
+++ b/src/WebServer/Rest/UriParameter.cs
@@ -1,4 +1,5 @@
 using System;
+using Restup.WebServer;
 
 namespace Restup.Webserver.Rest
 {
@@ -36,7 +37,7 @@ namespace Restup.Webserver.Rest
         {
             unchecked
             {
-                return ((Name?.GetHashCode() ?? 0)*397) ^ (Value?.GetHashCode() ?? 0);
+                return ((Name?.GetHashCode() ?? 0) * Constants.HashCodePrime) ^ (Value?.GetHashCode() ?? 0);
             }
         }
     }

--- a/src/WebServer/WebServer.csproj
+++ b/src/WebServer/WebServer.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Rest\PathParameterValueGetter.cs" />
     <Compile Include="Rest\PathPart.cs" />
     <Compile Include="Rest\QueryParameterValueGetter.cs" />
+    <Compile Include="Rest\RestControllerMethodInfoValidator.cs" />
     <Compile Include="Rest\RestMethodExecutor.cs" />
     <Compile Include="Rest\RestRoutehandler.cs" />
     <Compile Include="Rest\RestControllerMethodWithContentExecutor.cs" />
@@ -179,6 +180,7 @@
     <Compile Include="Rest\RestControllerMethodExecutor.cs" />
     <Compile Include="Rest\RestServerRequestFactory.cs" />
     <Compile Include="Rest\RestToHttpResponseConverter.cs" />
+    <Compile Include="Rest\UniqueMatchUriAndVerbComparer.cs" />
     <Compile Include="Rest\UriParser.cs" />
     <Compile Include="Rest\UriParameter.cs" />
   </ItemGroup>

--- a/src/WebServer/WebServer.csproj
+++ b/src/WebServer/WebServer.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Attributes\RestControllerAttribute.cs" />
     <Compile Include="Attributes\UriFormatAttribute.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="EncodingCache.cs" />
     <Compile Include="File\IFile.cs" />
     <Compile Include="File\IFileSystem.cs" />


### PR DESCRIPTION
This pull request adds validation to ensure that unique uris are registered within all the controllers registered. A uri is considered unique when a UriFormat and a verb are the same, this is done by using a   `UniqueMatchUriAndVerbRestControllerMethodInfoComparer`.

This fixes #79.

Any questions let me know. @tomkuijsten would you mind reviewing?

P.S. I've got some fixes done for #80 and #85 as well but need to spend some time picking them apart from https://github.com/Jark/restup/commits/feature-validate-rest-controller-method-info
