### PR TITLE
Added more validation around UriFormat to method mapping logic.

### DIFF
--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
@@ -80,6 +80,54 @@ namespace Restup.Webserver.UnitTests.Rest
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
         }
 
+        private class UriFormatWitMisnamedPathInUrlController
+        {
+            [UriFormat("/Get/{param}/")]
+            public IGetResponse Get(string param2) => new GetResponse(GetResponse.ResponseStatus.OK, param2);
+        }
+
+        [TestMethod]
+        public void RegisterController_AControllerWithMismatchedParametersInPath_ThrowsException()
+        {
+            AssertRegisterControllerThrows<UriFormatWitMisnamedPathInUrlController>();
+        }
+
+        private class UriFormatWitMisnamedUriParameterInUrlController
+        {
+            [UriFormat("/Get/?param={param}")]
+            public IGetResponse Get(string param2) => new GetResponse(GetResponse.ResponseStatus.OK, param2);
+        }
+
+        [TestMethod]
+        public void RegisterController_AControllerWithMismatchedParametersInUriParameters_ThrowsException()
+        {
+            AssertRegisterControllerThrows<UriFormatWitMisnamedUriParameterInUrlController>();
+        }
+
+        private class UriFormatWithMoreInUrlPathController
+        {
+            [UriFormat("/Get/{param}/{param2}")]
+            public IGetResponse Get(string param) => new GetResponse(GetResponse.ResponseStatus.OK, param);
+        }
+
+        [TestMethod]
+        public void RegisterController_AControllerWithMoreInUrlPath_ThrowsException()
+        {
+            AssertRegisterControllerThrows<UriFormatWithMoreInUrlPathController>();
+        }
+
+        private class UriFormatWithMoreInUrlParameterController
+        {
+            [UriFormat("/Get/?param={param}&param2={param}")]
+            public IGetResponse Get(string param) => new GetResponse(GetResponse.ResponseStatus.OK, param);
+        }
+
+        [TestMethod]
+        public void RegisterController_AControllerWithMoreInUrlParameter_ThrowsException()
+        {
+            AssertRegisterControllerThrows<UriFormatWithMoreInUrlParameterController>();
+        }
+
         private void AssertRegisterControllerThrows<T>(params string[] args) where T : class
         {
             Assert.ThrowsException<Exception>(() =>


### PR DESCRIPTION
This pull request adds test around uri format mapping and fixes the case where you have got more {param}'s defined in your `UriFormatAttribute` then there actually are. Fixes #80.

@tomkuijsten would you mind giving this a look-over? A simple change this time :)