### PR TITLE
Add validation around constructor args. 

### DIFF
--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
@@ -251,15 +251,16 @@ namespace Restup.Webserver.UnitTests.Rest
 
             string content = response.ToString();
 
+            // constructor validation will execute the Func once so initial value is set at + 1
             StringAssert.Contains(content, "\"Name\":\"Johathan\"");
-            StringAssert.Contains(content, "\"Age\":15");
+            StringAssert.Contains(content, "\"Age\":16");
 
             response = await m.HandleRequest(_basicControllerWithArgs);
 
             content = response.ToString();
 
             StringAssert.Contains(content, "\"Name\":\"Johathan\"");
-            StringAssert.Contains(content, "\"Age\":16");
+            StringAssert.Contains(content, "\"Age\":17");
         }
         #endregion
     }

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTest.Happy.cs
@@ -251,16 +251,15 @@ namespace Restup.Webserver.UnitTests.Rest
 
             string content = response.ToString();
 
-            // constructor validation will execute the Func once so initial value is set at + 1
             StringAssert.Contains(content, "\"Name\":\"Johathan\"");
-            StringAssert.Contains(content, "\"Age\":16");
+            StringAssert.Contains(content, "\"Age\":15");
 
             response = await m.HandleRequest(_basicControllerWithArgs);
 
             content = response.ToString();
 
             StringAssert.Contains(content, "\"Name\":\"Johathan\"");
-            StringAssert.Contains(content, "\"Age\":17");
+            StringAssert.Contains(content, "\"Age\":16");
         }
         #endregion
     }

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.ControllerConstructor.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.ControllerConstructor.cs
@@ -1,0 +1,61 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Restup.Webserver.UnitTests.TestHelpers;
+
+namespace Restup.Webserver.UnitTests.Rest
+{
+    [TestClass]
+    public class RestRouteHandlerTests_ControllerConstructor : RestRouteHandlerTests
+    {
+        private class ControllerWithOneStringParameter
+        {
+            public ControllerWithOneStringParameter(string param)
+            {
+            }
+        }
+
+        private class ControllerWithOneStringParameterAndOneIntegerParameter
+        {
+            public ControllerWithOneStringParameterAndOneIntegerParameter(string param, int param2)
+            {
+            }
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithAParameterAndNoParamIsPassedIn_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithOneStringParameter>();
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithAStringParameterAndAnIntegerIsPassedIn_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithOneStringParameter>(1);
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithAParameterAndMoreParamsArePassedIn_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithOneStringParameter>("param1", "param2");
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithAParameterAndTheCorrectParamsArePassedIn_ThenNoExceptionIsThrown()
+        {
+            _restRouteHandler.RegisterController<ControllerWithOneStringParameter>(() => new object[] { "param1" });
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithTwoParametersAndLessParamsArePassedIn_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithOneStringParameterAndOneIntegerParameter>("param1");
+        }
+
+        [TestMethod]
+        public void RegisterController_WithConstructerWithTwoParametersAndTheCorrectParamsArePassedIn_ThenNoExceptionIsThrown()
+        {
+            _restRouteHandler.RegisterController<ControllerWithOneStringParameterAndOneIntegerParameter>("param1", 1);
+            Assert.IsTrue(true);
+        }
+    }
+}

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.ControllerConstructor.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.ControllerConstructor.cs
@@ -20,6 +20,24 @@ namespace Restup.Webserver.UnitTests.Rest
             }
         }
 
+        private class ControllerWithPrivateConstructor
+        {
+            private ControllerWithPrivateConstructor()
+            {                
+            }
+        }
+
+        private class ControllerWithTwoConstructors
+        {
+            public ControllerWithTwoConstructors()
+            {
+            }
+
+            public ControllerWithTwoConstructors(string param)
+            {
+            }
+        }
+
         [TestMethod]
         public void RegisterController_WithConstructerWithAParameterAndNoParamIsPassedIn_ThenExceptionIsThrown()
         {
@@ -42,6 +60,25 @@ namespace Restup.Webserver.UnitTests.Rest
         public void RegisterController_WithConstructerWithAParameterAndTheCorrectParamsArePassedIn_ThenNoExceptionIsThrown()
         {
             _restRouteHandler.RegisterController<ControllerWithOneStringParameter>(() => new object[] { "param1" });
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public void RegisterController_WithPrivateConstructer_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithPrivateConstructor>(() => new object[] { "param1" });
+        }
+
+        [TestMethod]
+        public void RegisterController_WithTwoConstructersAndFuncIsUsed_ThenExceptionIsThrown()
+        {
+            AssertRegisterControllerThrows<ControllerWithTwoConstructors>(() => new object[] { "param1" });
+        }
+
+        [TestMethod]
+        public void RegisterController_WithTwoConstructersAndInstantiatedObjectIsUsed_ThenNoExceptionIsThrown()
+        {
+            _restRouteHandler.RegisterController<ControllerWithTwoConstructors>("param1");
             Assert.IsTrue(true);
         }
 

--- a/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
+++ b/src/WebServer.UnitTests/Rest/RestRouteHandlerTests.UriFormatValidation.cs
@@ -1,26 +1,17 @@
-﻿using Restup.HttpMessage.Models.Schemas;
+﻿using System;
+using System.Threading.Tasks;
+using Restup.HttpMessage.Models.Schemas;
 using Restup.Webserver.Attributes;
 using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;
-using Restup.Webserver.Rest;
 using Restup.Webserver.UnitTests.TestHelpers;
-using System;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Restup.Webserver.UnitTests.Rest
 {
     [TestClass]
-    public class RestRouteHandlerTests_UriFormatValidation
+    public class RestRouteHandlerTests_UriFormatValidation : RestRouteHandlerTests
     {
-        private RestRouteHandler restHandler;
-
-        [TestInitialize()]
-        public void Initialize()
-        {
-            restHandler = new RestRouteHandler();
-        }
-
         private class TwoUriFormatWithSameNameAndMethodController
         {
             [UriFormat("/Get")]
@@ -46,7 +37,7 @@ namespace Restup.Webserver.UnitTests.Rest
         [TestMethod]
         public async Task RegisterController_OneControllerRegisteredTwice_ThrowsException()
         {
-            restHandler.RegisterController<OnePostMethodController>();
+            _restRouteHandler.RegisterController<OnePostMethodController>();
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
             AssertRegisterControllerThrows<OnePostMethodController>();
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
@@ -65,7 +56,7 @@ namespace Restup.Webserver.UnitTests.Rest
         [TestMethod]
         public async Task RegisterController_OneParameterizedControllerRegisteredTwice_ThrowsException()
         {
-            restHandler.RegisterController<OnePostMethodWithParameterizedConstructorController>("param");
+            _restRouteHandler.RegisterController<OnePostMethodWithParameterizedConstructorController>("param");
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
             AssertRegisterControllerThrows<OnePostMethodWithParameterizedConstructorController>("param");
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
@@ -74,7 +65,7 @@ namespace Restup.Webserver.UnitTests.Rest
         [TestMethod]
         public async Task RegisterController_TwoDifferentControllersWithSimilarlyNamedMethodsAndVerbs_ThrowsException()
         {
-            restHandler.RegisterController<OnePostMethodController>();
+            _restRouteHandler.RegisterController<OnePostMethodController>();
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
             AssertRegisterControllerThrows<OnePostMethodWithParameterizedConstructorController>("param");
             await AssertHandleRequest("/Post", HttpMethod.POST, HttpResponseStatus.Created);
@@ -128,24 +119,10 @@ namespace Restup.Webserver.UnitTests.Rest
             AssertRegisterControllerThrows<UriFormatWithMoreInUrlParameterController>();
         }
 
-        private void AssertRegisterControllerThrows<T>(params string[] args) where T : class
-        {
-            Assert.ThrowsException<Exception>(() =>
-                restHandler.RegisterController<T>(args)
-            );
-        }
-
-        private void AssertRegisterControllerThrows<T>() where T : class
-        {
-            Assert.ThrowsException<Exception>(() =>
-                restHandler.RegisterController<T>()
-            );
-        }
-
         private async Task AssertHandleRequest(string uri, HttpMethod method, HttpResponseStatus expectedStatus)
         {
             var request = Utils.CreateHttpRequest(uri: new Uri(uri, UriKind.Relative), method: method);
-            var result = await restHandler.HandleRequest(request);
+            var result = await _restRouteHandler.HandleRequest(request);
 
             Assert.AreEqual(expectedStatus, result.ResponseStatus);
         }

--- a/src/WebServer.UnitTests/TestHelpers/RestRouteHandlerTests.cs
+++ b/src/WebServer.UnitTests/TestHelpers/RestRouteHandlerTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Restup.Webserver.Rest;
+
+namespace Restup.Webserver.UnitTests.TestHelpers
+{
+    public abstract class RestRouteHandlerTests
+    {
+        protected RestRouteHandler _restRouteHandler;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _restRouteHandler = new RestRouteHandler();
+        }
+
+        protected void AssertRegisterControllerThrows<T>(params object[] args) where T : class
+        {
+            Assert.ThrowsException<Exception>(() =>
+                _restRouteHandler.RegisterController<T>(args)
+            );
+        }
+
+        protected void AssertRegisterControllerThrows<T>() where T : class
+        {
+            Assert.ThrowsException<Exception>(() =>
+                _restRouteHandler.RegisterController<T>()
+            );
+        }
+    }
+}

--- a/src/WebServer.UnitTests/TestHelpers/RestRouteHandlerTests.cs
+++ b/src/WebServer.UnitTests/TestHelpers/RestRouteHandlerTests.cs
@@ -21,6 +21,13 @@ namespace Restup.Webserver.UnitTests.TestHelpers
             );
         }
 
+        protected void AssertRegisterControllerThrows<T>(Func<object[]> args) where T : class
+        {
+            Assert.ThrowsException<Exception>(() =>
+                _restRouteHandler.RegisterController<T>(args)
+            );
+        }
+
         protected void AssertRegisterControllerThrows<T>() where T : class
         {
             Assert.ThrowsException<Exception>(() =>

--- a/src/WebServer.UnitTests/WebServer.UnitTests.csproj
+++ b/src/WebServer.UnitTests/WebServer.UnitTests.csproj
@@ -98,7 +98,9 @@
     <Compile Include="File\MimeTypeProviderTests.cs" />
     <Compile Include="Http\HttpServerTests.CorsSimpleRequests.cs" />
     <Compile Include="Http\HttpServerTests.CorsPreflightedRequests.cs" />
+    <Compile Include="Rest\RestRouteHandlerTests.ControllerConstructor.cs" />
     <Compile Include="Rest\RestRouteHandlerTests.UriFormatValidation.cs" />
+    <Compile Include="TestHelpers\RestRouteHandlerTests.cs" />
     <Compile Include="TestHelpers\MockFile.cs" />
     <Compile Include="TestHelpers\MockFileSystem.cs" />
     <Compile Include="TestHelpers\StaticFileRouteHandlerTests.Fluent.cs" />

--- a/src/WebServer/InstanceCreators/PerCallInstanceCreator.cs
+++ b/src/WebServer/InstanceCreators/PerCallInstanceCreator.cs
@@ -1,13 +1,14 @@
 ﻿using Restup.Webserver.Models.Contracts;
 using System;
+using System.Reflection;
 
 namespace Restup.Webserver.InstanceCreators
 {
     internal class PerCallInstanceCreator : IInstanceCreator
     {
-        public object Create(Type instanceType, params object[] args)
+        public object Create(ConstructorInfo instanceType, object[] args)
         {
-            return Activator.CreateInstance(instanceType, args);
+            return instanceType.Invoke(args);
         }
     }
 }

--- a/src/WebServer/InstanceCreators/SingletonInstanceCreator.cs
+++ b/src/WebServer/InstanceCreators/SingletonInstanceCreator.cs
@@ -1,21 +1,22 @@
-﻿using Restup.Webserver.Models.Contracts;
-using System;
+﻿using System;
+using System.Reflection;
+using Restup.Webserver.Models.Contracts;
 
 namespace Restup.Webserver.InstanceCreators
 {
     internal class SingletonInstanceCreator : IInstanceCreator
     {
         private object _instance;
-        private object _instanceLock = new object();
+        private readonly object _instanceLock = new object();
 
-        public object Create(Type instanceType, params object[] args)
+        public object Create(ConstructorInfo instanceType, object[] args)
         {
             CacheInstance(instanceType, args);
 
             return _instance;
         }
 
-        private void CacheInstance(Type instanceType, object[] args)
+        private void CacheInstance(ConstructorInfo instanceType, object[] args)
         {
             if (_instance == null)
             {
@@ -23,7 +24,7 @@ namespace Restup.Webserver.InstanceCreators
                 {
                     if (_instance == null)
                     {
-                        _instance = Activator.CreateInstance(instanceType, args);
+                        _instance = instanceType.Invoke(args);
                     }
                 }
             }

--- a/src/WebServer/Models/Contracts/IInstanceCreator.cs
+++ b/src/WebServer/Models/Contracts/IInstanceCreator.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Restup.Webserver.Models.Contracts
 {
     interface IInstanceCreator
     {
-        object Create(Type instanceType, object[] args);
+        object Create(ConstructorInfo instanceType, object[] args);
     }
 }

--- a/src/WebServer/Rest/ReflectionHelper.cs
+++ b/src/WebServer/Rest/ReflectionHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Restup.Webserver.Rest
+{
+    internal static class ReflectionHelper
+    {
+        internal static bool TryFindMatchingConstructor<T>(Func<object[]> constructorArgs, out ConstructorInfo foundConstructor)
+        {
+            var args = constructorArgs();
+            foreach (var constructorInfo in typeof(T).GetConstructors())
+            {
+                var parameters = constructorInfo.GetParameters();
+                if (args.Length != parameters.Length)
+                    continue;
+
+                var argsTypes = args.Select(x => x.GetType());
+                var parameterTypes = parameters.Select(x => x.ParameterType);
+                if (!argsTypes.SequenceEqual(parameterTypes, new TypeComparer()))
+                    continue;
+
+                foundConstructor = constructorInfo;
+                return true;
+            }
+            foundConstructor = null;
+            return false;
+        }
+
+        private class TypeComparer : IEqualityComparer<Type>
+        {
+            public bool Equals(Type x, Type y)
+            {
+                return x == y;
+            }
+
+            public int GetHashCode(Type obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/WebServer/Rest/ReflectionHelper.cs
+++ b/src/WebServer/Rest/ReflectionHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -18,7 +17,7 @@ namespace Restup.Webserver.Rest
 
                 var argsTypes = args.Select(x => x.GetType());
                 var parameterTypes = parameters.Select(x => x.ParameterType);
-                if (!argsTypes.SequenceEqual(parameterTypes, new TypeComparer()))
+                if (!argsTypes.SequenceEqual(parameterTypes))
                     continue;
 
                 foundConstructor = constructorInfo;
@@ -26,19 +25,6 @@ namespace Restup.Webserver.Rest
             }
             foundConstructor = null;
             return false;
-        }
-
-        private class TypeComparer : IEqualityComparer<Type>
-        {
-            public bool Equals(Type x, Type y)
-            {
-                return x == y;
-            }
-
-            public int GetHashCode(Type obj)
-            {
-                return obj.GetHashCode();
-            }
         }
     }
 }

--- a/src/WebServer/Rest/ReflectionHelper.cs
+++ b/src/WebServer/Rest/ReflectionHelper.cs
@@ -6,9 +6,8 @@ namespace Restup.Webserver.Rest
 {
     internal static class ReflectionHelper
     {
-        internal static bool TryFindMatchingConstructor<T>(Func<object[]> constructorArgs, out ConstructorInfo foundConstructor)
+        internal static bool TryFindMatchingConstructor<T>(object[] args, out ConstructorInfo foundConstructor)
         {
-            var args = constructorArgs();
             foreach (var constructorInfo in typeof(T).GetConstructors())
             {
                 var parameters = constructorInfo.GetParameters();
@@ -17,7 +16,7 @@ namespace Restup.Webserver.Rest
 
                 var argsTypes = args.Select(x => x.GetType());
                 var parameterTypes = parameters.Select(x => x.ParameterType);
-                if (!argsTypes.SequenceEqual(parameterTypes))
+                if ( !argsTypes.SequenceEqual(parameterTypes))
                     continue;
 
                 foundConstructor = constructorInfo;

--- a/src/WebServer/Rest/RestControllerMethodExecutor.cs
+++ b/src/WebServer/Rest/RestControllerMethodExecutor.cs
@@ -29,7 +29,7 @@ namespace Restup.Webserver.Rest
             }
 
             return info.MethodInfo.Invoke(
-                    instantiator.Create(info.MethodInfo.DeclaringType, info.ControllerConstructorArgs()),
+                    instantiator.Create(info.ControllerConstructor, info.ControllerConstructorArgs()),
                     parameters);
         }
     }

--- a/src/WebServer/Rest/RestControllerMethodInfo.cs
+++ b/src/WebServer/Rest/RestControllerMethodInfo.cs
@@ -28,14 +28,13 @@ namespace Restup.Webserver.Rest
         internal bool HasContentParameter { get; }
         internal Type ContentParameterType { get; }
         internal TypeWrapper ReturnTypeWrapper { get; }
+        internal ConstructorInfo ControllerConstructor { get; }
         internal Func<object[]> ControllerConstructorArgs { get; }
 
-        internal RestControllerMethodInfo(
-            MethodInfo methodInfo,
-            Func<object[]> constructorArgs,
-            TypeWrapper typeWrapper)
+        internal RestControllerMethodInfo(MethodInfo methodInfo, ConstructorInfo constructor, Func<object[]> constructorArgs, TypeWrapper typeWrapper)
         {
-            constructorArgs.GuardNull(nameof(constructorArgs));
+            ControllerConstructor = constructor;
+
             _uriParser = new UriParser();
             MatchUri = GetUriFromMethod(methodInfo);
 

--- a/src/WebServer/Rest/RestControllerMethodWithContentExecutor.cs
+++ b/src/WebServer/Rest/RestControllerMethodWithContentExecutor.cs
@@ -53,7 +53,7 @@ namespace Restup.Webserver.Rest
             }
 
             return info.MethodInfo.Invoke(
-                    instantiator.Create(info.MethodInfo.DeclaringType, info.ControllerConstructorArgs()),
+                    instantiator.Create(info.ControllerConstructor, info.ControllerConstructorArgs()),
                     parameters);
         }
     }

--- a/src/WebServer/Rest/RestControllerRequestHandler.cs
+++ b/src/WebServer/Rest/RestControllerRequestHandler.cs
@@ -30,22 +30,31 @@ namespace Restup.Webserver.Rest
             _restControllerMethodInfoValidator = new RestControllerMethodInfoValidator();
         }
 
-        internal void RegisterController<T>() where T : class
-        {
-            RegisterController<T>(() => Enumerable.Empty<object>().ToArray());
-        }
-
-        internal void RegisterController<T>(Func<object[]> constructorArgs) where T : class
+        internal void RegisterController<T>(params object[] constructorArgs) where T : class
         {
             constructorArgs.GuardNull(nameof(constructorArgs));
 
             ConstructorInfo constructorInfo;
             if (!ReflectionHelper.TryFindMatchingConstructor<T>(constructorArgs, out constructorInfo))
             {
-                throw new Exception($"No constructor found on {typeof (T)} that matches passed in constructor arguments.");
+                throw new Exception($"No constructor found on {typeof(T)} that matches passed in constructor arguments.");
             }
 
-            var restControllerMethodInfos = GetRestMethods<T>(constructorArgs, constructorInfo);
+            var restControllerMethodInfos = GetRestMethods<T>(() => constructorArgs, constructorInfo);
+            AddRestMethods<T>(restControllerMethodInfos);
+        }
+
+        internal void RegisterController<T>(Func<object[]> constructorArgs) where T : class
+        {
+            constructorArgs.GuardNull(nameof(constructorArgs));
+
+            var constructorInfos = typeof (T).GetConstructors();
+            if (constructorInfos.Length > 1)
+                throw new Exception("More than one constructor defined.");
+            if (constructorInfos.Length == 0)
+                throw new Exception("No public constructor defined.");
+
+            var restControllerMethodInfos = GetRestMethods<T>(constructorArgs, constructorInfos.Single());
             AddRestMethods<T>(restControllerMethodInfos);
         }
 

--- a/src/WebServer/Rest/RestRouteHandler.cs
+++ b/src/WebServer/Rest/RestRouteHandler.cs
@@ -25,9 +25,10 @@ namespace Restup.Webserver.Rest
 
         public void RegisterController<T>(params object[] args) where T : class
         {
-            _requestHandler.RegisterController<T>(() => args);
+            _requestHandler.RegisterController<T>(args);
         }
 
+        [Obsolete("Use the RegisterController which takes instantiated arguments.")]
         public void RegisterController<T>(Func<object[]> args) where T : class
         {
             _requestHandler.RegisterController<T>(args);

--- a/src/WebServer/WebServer.csproj
+++ b/src/WebServer/WebServer.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Rest\PathParameterValueGetter.cs" />
     <Compile Include="Rest\PathPart.cs" />
     <Compile Include="Rest\QueryParameterValueGetter.cs" />
+    <Compile Include="Rest\ReflectionHelper.cs" />
     <Compile Include="Rest\RestControllerMethodInfoValidator.cs" />
     <Compile Include="Rest\RestMethodExecutor.cs" />
     <Compile Include="Rest\RestRoutehandler.cs" />


### PR DESCRIPTION
This fixes #85, unfortunately we have to execute the Func<T> args once to do the validation properly.

I think ideally we'd do a simplification to get rid of `public void RegisterController<T>(params object[] args)` and `public void RegisterController<T>(Func<object[]> args)` by using dependency injection. And preferably also the ability to create singleton controllers, I don't see what the use case for singleton controllers would be anyway. I guess it does make the initial play with restup easier.

An example of the design with dependency injection would be:
```cs
[RestController]
public sealed class ParameterController
{
    private readonly IParameterStore parameterStore;

    public ParameterController(IParameterStore parameterStore)
    {
        this.parameterStore = parameterStore;
    }

    [UriFormat("/parameter/{id}/{propName}")]
    public IGetResponse GetValue(int id, string propName)
    {
        object value;
        if (parameterStore.TryGet(id, propName, out value))
        {
            return new GetResponse(GetResponse.ResponseStatus.OK, new { Id = id, Prop = propName, Value = value });
        }

        return new GetResponse(GetResponse.ResponseStatus.NotFound, new { Id = id, Prop = propName });
    }
}

public interface IParameterStore
{
    bool TryGet(int id, string propName, out object value);
}

public  interface IDependencyResolver : IDisposable
{
    object GetService(Type serviceType);
    void Register(Type serviceType, Func<object> activator);
}
```

And then the initialisation of the http server with rest would be:

```cs
// setup stores to backend processes
var store = new ParameterStore();

// setup rest route handler
var restRouteHandler = new RestRouteHandler();
restRouteHandler.DependencyResolver.Register(typeof (IParameterStore), () => store);
restRouteHandler.RegisterController<ParameterController>();

// setup http server config
var config = new HttpServerConfiguration()
    .RegisterRoute(restRouteHandler)
    .ListenOnPort(80);

// create & start server
var httpServer = new HttpServer(config);
httpServer.StartServerAsync().Wait();
```

Let me know what you think about the code change and the design above. If the design needs work then maybe we can create a separate issue for this.