### PR TITLE
implement basic authorization module

### DIFF
--- a/scripts/.vscode/launch.json
+++ b/scripts/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Launch (current file)",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}"
+        }
+    ]
+}

--- a/src/DemoControllers/AuthenticatedPerCallControllerSample.cs
+++ b/src/DemoControllers/AuthenticatedPerCallControllerSample.cs
@@ -1,0 +1,36 @@
+﻿using Restup.Webserver.Attributes;
+using Restup.Webserver.Models.Contracts;
+using Restup.Webserver.Models.Schemas;
+using Restup.WebServer.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.DemoControllers
+{
+	[Authorize]
+	[RestController(InstanceCreationType.PerCall)]
+	public sealed class AuthenticatedPerCallControllerSample
+	{
+		private long _totalNrOfCallsHandled;
+
+		private class CallInfo
+		{
+			public long TotalCallsHandled { get; set; }
+		}
+
+		/// <summary>
+		/// This will always return a TotalCallsHandled of one, no matter how many times you request this uri.
+		/// </summary>
+		/// <returns></returns>
+		[UriFormat("/authpercall")]
+		public IGetResponse GetPerCallSampleValue()
+		{
+			return new GetResponse(
+				GetResponse.ResponseStatus.OK,
+				new CallInfo() { TotalCallsHandled = ++_totalNrOfCallsHandled });
+		}
+	}
+}

--- a/src/DemoControllers/Authentication/DemoCredentialValidator.cs
+++ b/src/DemoControllers/Authentication/DemoCredentialValidator.cs
@@ -1,0 +1,18 @@
+﻿using Restup.Webserver.Models.Contracts;
+using Restup.WebServer.Models.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.DemoControllers.Authentication
+{
+	public sealed class DemoCredentialValidator : ICredentialValidator
+	{
+		public bool Authenticate(string username, string password)
+		{
+			return (username == "user" && password == "pass");
+		}
+	}
+}

--- a/src/DemoControllers/DemoControllers.csproj
+++ b/src/DemoControllers/DemoControllers.csproj
@@ -107,6 +107,8 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuthenticatedPerCallControllerSample.cs" />
+    <Compile Include="Authentication\DemoCredentialValidator.cs" />
     <Compile Include="Model\DataReceived.cs" />
     <Compile Include="Model\FromContentData.cs" />
     <Compile Include="Model\MoreComplexData.cs" />

--- a/src/HeadedDemo/MainPage.xaml.cs
+++ b/src/HeadedDemo/MainPage.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using Restup.DemoControllers;
+using Restup.DemoControllers.Authentication;
 using Restup.Webserver.File;
 using Restup.Webserver.Http;
 using Restup.Webserver.Rest;
+using Restup.WebServer.Http;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -29,12 +31,14 @@ namespace Restup.HeadedDemo
 
         private async Task InitializeWebServer()
         {
-            var restRouteHandler = new RestRouteHandler();
+			var authProvider = new BasicAuthorizationProvider("Please login", new DemoCredentialValidator());
+			var restRouteHandler = new RestRouteHandler(authProvider);
 
             restRouteHandler.RegisterController<AsyncControllerSample>();
             restRouteHandler.RegisterController<FromContentControllerSample>();
             restRouteHandler.RegisterController<PerCallControllerSample>();
-            restRouteHandler.RegisterController<SimpleParameterControllerSample>();
+			restRouteHandler.RegisterController<AuthenticatedPerCallControllerSample>();
+			restRouteHandler.RegisterController<SimpleParameterControllerSample>();
             restRouteHandler.RegisterController<SingletonControllerSample>();
             restRouteHandler.RegisterController<ThrowExceptionControllerSample>();
             restRouteHandler.RegisterController<WithResponseContentControllerSample>();
@@ -42,8 +46,8 @@ namespace Restup.HeadedDemo
             var configuration = new HttpServerConfiguration()
                 .ListenOnPort(8800)
                 .RegisterRoute("api", restRouteHandler)
-                .RegisterRoute(new StaticFileRouteHandler(@"Restup.DemoStaticFiles\Web"))
-                .EnableCors(); // allow cors requests on all origins
+                .RegisterRoute(new StaticFileRouteHandler(@"Restup.DemoStaticFiles\Web", authProvider))
+				.EnableCors(); // allow cors requests on all origins
                                //.EnableCors(x => x.AddAllowedOrigin("http://specificserver:<listen-port>"));
 
             var httpServer = new HttpServer(configuration);

--- a/src/HeadlessDemo/StartupTask.cs
+++ b/src/HeadlessDemo/StartupTask.cs
@@ -1,7 +1,9 @@
 ﻿using Restup.DemoControllers;
+using Restup.DemoControllers.Authentication;
 using Restup.Webserver.File;
 using Restup.Webserver.Http;
 using Restup.Webserver.Rest;
+using Restup.WebServer.Http;
 using Windows.ApplicationModel.Background;
 
 // The Background Application template is documented at http://go.microsoft.com/fwlink/?LinkID=533884&clcid=0x409
@@ -25,21 +27,23 @@ namespace Restup.HeadlessDemo
             // come some day, see that this method is not active anymore and the local variable
             // should be removed. Which results in the application being closed.
             _deferral = taskInstance.GetDeferral();
-            var restRouteHandler = new RestRouteHandler();
+			var authProvider = new BasicAuthorizationProvider("Please login", new DemoCredentialValidator());
+			var restRouteHandler = new RestRouteHandler(authProvider);
 
-            restRouteHandler.RegisterController<AsyncControllerSample>();
+			restRouteHandler.RegisterController<AsyncControllerSample>();
             restRouteHandler.RegisterController<FromContentControllerSample>();
-            restRouteHandler.RegisterController<PerCallControllerSample>();
+			restRouteHandler.RegisterController<AuthenticatedPerCallControllerSample>();
+			restRouteHandler.RegisterController<PerCallControllerSample>();
             restRouteHandler.RegisterController<SimpleParameterControllerSample>();
             restRouteHandler.RegisterController<SingletonControllerSample>();
             restRouteHandler.RegisterController<ThrowExceptionControllerSample>();
             restRouteHandler.RegisterController<WithResponseContentControllerSample>();
 
-            var configuration = new HttpServerConfiguration()
-                .ListenOnPort(8800)
-                .RegisterRoute("api", restRouteHandler)
-                .RegisterRoute(new StaticFileRouteHandler(@"Restup.DemoStaticFiles\Web"))
-                .EnableCors(); // allow cors requests on all origins
+			var configuration = new HttpServerConfiguration()
+				.ListenOnPort(8800)
+				.RegisterRoute("api", restRouteHandler)
+				.RegisterRoute(new StaticFileRouteHandler(@"Restup.DemoStaticFiles\Web", authProvider))
+				.EnableCors(); // allow cors requests on all origins
             //  .EnableCors(x => x.AddAllowedOrigin("http://specificserver:<listen-port>"));
 
             var httpServer = new HttpServer(configuration);

--- a/src/HttpMessage/Contracts/IAuthorizationProvider.cs
+++ b/src/HttpMessage/Contracts/IAuthorizationProvider.cs
@@ -1,0 +1,16 @@
+﻿using Restup.HttpMessage;
+using Restup.HttpMessage.Models.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Models.Contracts
+{
+	public interface IAuthorizationProvider
+	{
+		string Realm { get; }
+		HttpResponseStatus Authorize(IHttpServerRequest request);
+	}
+}

--- a/src/HttpMessage/HttpMessage.projitems
+++ b/src/HttpMessage/HttpMessage.projitems
@@ -9,6 +9,10 @@
     <Import_RootNamespace>Restup.HttpMessage</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Schemas\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Contracts\IAuthorizationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\HttpHeaderBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\HttpRequestHeaderBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Request\AcceptCharsetHeader.cs" />
@@ -32,16 +36,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\AllowHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\CloseConnectionHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\ContentEncodingHeader.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\ContentTypeHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\ContentLengthHeader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\ContentTypeHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\DateHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\Response\LocationHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\UntypedRequestHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Headers\UntypedResponseHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpServerRequest.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)IHttpServerRequest.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)MutableHttpServerRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpServerResponse.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IHttpServerRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Contracts\IHttpHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Contracts\IHttpRequestHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Contracts\IHttpRequestHeaderVisitor.cs" />
@@ -51,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Schemas\HttpMethod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Schemas\HttpResponseStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Schemas\StreamReadResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MutableHttpServerRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plumbing\Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plumbing\Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plumbing\HttpCodesTranslator.cs" />

--- a/src/Restup.sln
+++ b/src/Restup.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Webserver", "Webserver\Webserver.csproj", "{837B8FF3-DED6-4DC7-AD58-DBB0B3E44DD4}"
 EndProject
@@ -29,8 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebServer.Logging", "WebSer
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		HttpMessage\HttpMessage.projitems*{837b8ff3-ded6-4dc7-ad58-dbb0b3e44dd4}*SharedItemsImports = 4
 		HttpMessage\HttpMessage.projitems*{13aba022-a7c1-45b7-9e47-2bb74f2a7f9f}*SharedItemsImports = 13
+		HttpMessage\HttpMessage.projitems*{837b8ff3-ded6-4dc7-ad58-dbb0b3e44dd4}*SharedItemsImports = 4
 		HttpMessage\HttpMessage.projitems*{d313f525-2d90-4bf5-8857-2698ee580a65}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/WebServer.UnitTests/TestHelpers/StaticFileRouteHandlerTests.Fluent.cs
+++ b/src/WebServer.UnitTests/TestHelpers/StaticFileRouteHandlerTests.Fluent.cs
@@ -20,7 +20,7 @@ namespace Restup.Webserver.UnitTests.TestHelpers
         public StaticFileRouteHandlerFluentTests SetUp(string basePath, bool pathExists = true)
         {
             mockFileSystem = new MockFileSystem(pathExists);
-            routeHandler = new StaticFileRouteHandler(basePath, null, mockFileSystem);
+            routeHandler = new StaticFileRouteHandler(basePath, null, mockFileSystem, null);
 
             return this;
         }

--- a/src/WebServer/Attributes/AuthorizeAttribute.cs
+++ b/src/WebServer/Attributes/AuthorizeAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Attributes
+{
+	public class AuthorizeAttribute : Attribute
+	{
+	}
+}

--- a/src/WebServer/Http/BasicAuthorizationProvider.cs
+++ b/src/WebServer/Http/BasicAuthorizationProvider.cs
@@ -1,0 +1,48 @@
+﻿using Restup.HttpMessage;
+using Restup.HttpMessage.Models.Schemas;
+using Restup.Webserver.Models.Contracts;
+using Restup.WebServer.Models.Contracts;
+using Restup.WebServer.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Http
+{
+	public class BasicAuthorizationProvider : IAuthorizationProvider
+	{
+		private ICredentialValidator _credentialValidator;
+		private string _realm;
+
+		public BasicAuthorizationProvider(string realm, ICredentialValidator credentialValidator)
+		{
+			_realm = realm;
+			_credentialValidator = credentialValidator;
+		}
+
+		public string Realm { get { return _realm; } }
+
+		public HttpResponseStatus Authorize(IHttpServerRequest request)
+		{
+			if (request.Headers.Any(h => h.Name == "Authorization"))
+			{
+				var authValue = request.Headers.Single(h => h.Name == "Authorization").Value;
+				var pair = Base64.DecodeFrom64(authValue.Split(' ')[1]).Split(':');
+				var user = pair[0];
+				var pass = pair[1];
+
+				if (!_credentialValidator.Authenticate(user, pass))
+				{
+					return HttpResponseStatus.Unauthorized;
+				}
+				return HttpResponseStatus.OK;
+			}
+			else // ask for authentication headers
+			{
+				return HttpResponseStatus.Unauthorized;
+			}
+		}
+	}
+}

--- a/src/WebServer/Models/Schemas/InternalServerErrorResponse.cs
+++ b/src/WebServer/Models/Schemas/InternalServerErrorResponse.cs
@@ -1,0 +1,18 @@
+﻿using Restup.HttpMessage.Models.Schemas;
+using Restup.Webserver.Models.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Models.Schemas
+{
+	internal class InternalServerErrorResponse : StatusOnlyResponse
+	{
+		internal InternalServerErrorResponse() : base((int)HttpResponseStatus.InternalServerError)
+		{
+
+		}
+	}
+}

--- a/src/WebServer/Models/Schemas/WwwAuthenticateResponse.cs
+++ b/src/WebServer/Models/Schemas/WwwAuthenticateResponse.cs
@@ -1,0 +1,18 @@
+﻿using Restup.HttpMessage.Models.Schemas;
+using Restup.Webserver.Models.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Models.Schemas
+{
+	internal class WwwAuthenticateResponse : StatusOnlyResponse
+	{
+		internal WwwAuthenticateResponse(string realm) : base((int)HttpResponseStatus.Unauthorized, new Dictionary<string, string>() { { "WWW-Authenticate", $"Basic realm=\"{realm}\"" } })
+		{
+
+		}
+	}
+}

--- a/src/WebServer/Rest/RestResponseFactory.cs
+++ b/src/WebServer/Rest/RestResponseFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Restup.Webserver.Models.Contracts;
 using Restup.Webserver.Models.Schemas;
+using Restup.WebServer.Models.Schemas;
 
 namespace Restup.Webserver.Rest
 {
@@ -16,5 +17,15 @@ namespace Restup.Webserver.Rest
         {
             return _badRequestResponse;
         }
+
+		internal IRestResponse CreateWwwAuthenticate(string Realm)
+		{
+			return new WwwAuthenticateResponse(Realm);
+		}
+
+		internal IRestResponse CreateInternalServerError()
+		{
+			return new InternalServerErrorResponse();
+		}
     }
 }

--- a/src/WebServer/Rest/RestRouteHandler.cs
+++ b/src/WebServer/Rest/RestRouteHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Restup.HttpMessage;
 using Restup.Webserver.Models.Contracts;
+using Restup.WebServer.Models.Contracts;
 using System;
 using System.Threading.Tasks;
 
@@ -10,13 +11,20 @@ namespace Restup.Webserver.Rest
         private readonly RestControllerRequestHandler _requestHandler;
         private readonly RestToHttpResponseConverter _restToHttpConverter;
         private readonly RestServerRequestFactory _restServerRequestFactory;
+		private readonly IAuthorizationProvider _authenticationProvider;
 
-        public RestRouteHandler()
+
+		public RestRouteHandler()
         {
             _restServerRequestFactory = new RestServerRequestFactory();
             _requestHandler = new RestControllerRequestHandler();
             _restToHttpConverter = new RestToHttpResponseConverter();
         }
+
+		public RestRouteHandler(IAuthorizationProvider authenticationProvider) : this()
+		{
+			_authenticationProvider = authenticationProvider;
+		}
 
         public void RegisterController<T>() where T : class
         {
@@ -37,7 +45,7 @@ namespace Restup.Webserver.Rest
         {
             var restServerRequest = _restServerRequestFactory.Create(request);
 
-            var restResponse = await _requestHandler.HandleRequestAsync(restServerRequest);
+            var restResponse = await _requestHandler.HandleRequestAsync(restServerRequest, _authenticationProvider);
 
             var httpResponse = _restToHttpConverter.ConvertToHttpResponse(restResponse, restServerRequest);
 

--- a/src/WebServer/Utils/Base64.cs
+++ b/src/WebServer/Utils/Base64.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.WebServer.Utils
+{
+	public static class Base64
+	{
+		static public string EncodeTo64(string toEncode)
+		{
+			byte[] toEncodeAsBytes
+		  = System.Text.ASCIIEncoding.ASCII.GetBytes(toEncode);
+			string returnValue
+		  = System.Convert.ToBase64String(toEncodeAsBytes);
+			return returnValue;
+		}
+
+		static public string DecodeFrom64(string encodedData)
+		{
+			byte[] encodedDataAsBytes
+		  = System.Convert.FromBase64String(encodedData);
+			string returnValue =
+		   System.Text.ASCIIEncoding.ASCII.GetString(encodedDataAsBytes);
+			return returnValue;
+		}
+	}
+}

--- a/src/WebServer/WebServer.csproj
+++ b/src/WebServer/WebServer.csproj
@@ -115,6 +115,7 @@
     <AssemblyOriginatorKeyFile>restup-tmp1.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Attributes\AuthorizeAttribute.cs" />
     <Compile Include="Attributes\FromContentAttribute.cs" />
     <Compile Include="Attributes\RestControllerAttribute.cs" />
     <Compile Include="Attributes\UriFormatAttribute.cs" />
@@ -127,6 +128,7 @@
     <Compile Include="File\PhysicalFileSystem.cs" />
     <Compile Include="File\StaticFileRouteHandler.cs" />
     <Compile Include="Http\AfterHandleRequestResult.cs" />
+    <Compile Include="Http\BasicAuthorizationProvider.cs" />
     <Compile Include="Http\BeforeHandleRequestResult.cs" />
     <Compile Include="Http\ContentCoding.cs" />
     <Compile Include="Http\CompressContentEncoder.cs" />
@@ -143,9 +145,11 @@
     <Compile Include="Http\RouteRegistration.cs" />
     <Compile Include="LogManager.cs" />
     <Compile Include="Models\Contracts\IRouteHandler.cs" />
+    <Compile Include="Models\Schemas\InternalServerErrorResponse.cs" />
     <Compile Include="Models\Schemas\MediaType.cs" />
     <Compile Include="Models\Schemas\RestResponse.cs" />
     <Compile Include="Models\Schemas\RestServerRequest.cs" />
+    <Compile Include="Models\Schemas\WwwAuthenticateResponse.cs" />
     <Compile Include="Rest\MatchUri.cs" />
     <Compile Include="Rest\ParameterValueGetter.cs" />
     <Compile Include="Rest\ParsedUri.cs" />
@@ -181,6 +185,7 @@
     <Compile Include="Rest\RestToHttpResponseConverter.cs" />
     <Compile Include="Rest\UriParser.cs" />
     <Compile Include="Rest\UriParameter.cs" />
+    <Compile Include="Utils\Base64.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/WebServer/project.lock.json
+++ b/src/WebServer/project.lock.json
@@ -11843,19 +11843,18 @@
       ]
     },
     "Microsoft.ApplicationInsights.WindowsApps/1.0.0": {
-      "sha512": "NvBQnFeiFd0O1QdBz06UGApD7zn7ztVi7qO18IsM3EjiXRNgfrEBXB+azNm8XqLY8xGFAqh3HAuSd/wHZMe0XA==",
-      "type": "Package",
+      "sha512": "fNCAjIwvbTV+G0dT14bgM5tptsqeSaKQaCrlq7QknOq1Xdm8ZmgsDYddMgXkvykyKLjWyU6fKuOpj6fsQJy+wQ==",
+      "type": "package",
+      "path": "Microsoft.ApplicationInsights.WindowsApps/1.0.0",
       "files": [
+        "Microsoft.ApplicationInsights.WindowsApps.1.0.0.nupkg.sha512",
         "Microsoft.ApplicationInsights.WindowsApps.nuspec",
-        "[Content_Types].xml",
-        "_rels/.rels",
         "lib/win81/Microsoft.ApplicationInsights.Extensibility.Windows.XML",
         "lib/win81/Microsoft.ApplicationInsights.Extensibility.Windows.dll",
         "lib/wp8/Microsoft.ApplicationInsights.Extensibility.Windows.XML",
         "lib/wp8/Microsoft.ApplicationInsights.Extensibility.Windows.dll",
         "lib/wpa81/Microsoft.ApplicationInsights.Extensibility.Windows.XML",
-        "lib/wpa81/Microsoft.ApplicationInsights.Extensibility.Windows.dll",
-        "package/services/metadata/core-properties/4f6f732debe548beaa1183418e8d65cc.psmdcp"
+        "lib/wpa81/Microsoft.ApplicationInsights.Extensibility.Windows.dll"
       ]
     },
     "Microsoft.CSharp/4.0.0": {

--- a/src/Webserver.Models/Contracts/ICredentialValidator.cs
+++ b/src/Webserver.Models/Contracts/ICredentialValidator.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Restup.Webserver.Models.Contracts
+{
+	public interface ICredentialValidator
+	{
+		bool Authenticate(string username, string password);
+	}
+}

--- a/src/Webserver.Models/Webserver.Models.csproj
+++ b/src/Webserver.Models/Webserver.Models.csproj
@@ -110,6 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Contracts\IContentRestResponse.cs" />
+    <Compile Include="Contracts\ICredentialValidator.cs" />
     <Compile Include="Contracts\IDeleteResponse.cs" />
     <Compile Include="Contracts\IGetResponse.cs" />
     <Compile Include="Contracts\IPostResponse.cs" />
@@ -120,9 +121,7 @@
   <ItemGroup>
     <Content Include="About.txt" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Schemas\" />
-  </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
@tomkuijsten I habe implemented the basic authorization. To activate it, you add an IAuthorizationProvider to the constructor of RestRouteHandler and StaticFileRouteHandler. So you can define which paths have authorization and which not. I would also like to add this to the wiki if you would make me a contributor of your project.
You have to pass an ICredentialValidator to the constructor of the BasicAuthorizationProvider. There you can implement username and password check.
Next I would implement another ICredentialValidator with pass through authentication that checks the username/password against the local administrator account, which is also used to log in to the admin interface of the pi.
Btw I did not yet write any unit tests but I tested locally and on the raspberry and it works fine.
